### PR TITLE
Deep clone the repo when building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - uses: denoland/setup-deno@v1
         with:


### PR DESCRIPTION
This will make sure pages with `"git created"` and `"git modified"` dates are built correctly in the CI. While there are no such pages currently, this will be needed for blog posts when they are added.