### PR TITLE
Remove the `role="list"` from the socials `<dl>` in the home page

### DIFF
--- a/_includes/home-layout.njk
+++ b/_includes/home-layout.njk
@@ -10,7 +10,7 @@ additional_css:
 <nav id="socials">
   <h1>Contact</h1>
 
-  <dl role="list">
+  <dl>
     <dt id="social-mastodon" title="Mastodon">Mastodon:</dd>
     <dd><a target="_new" rel="me" href="https://mastodon.andreubotella.com/@andreu">@andreu@andreubotella.com</a></dd>
     <dt id="social-cohost" title="Cohost">Cohost:</dt>


### PR DESCRIPTION
I don't remember why I added this, and in ARIA, the `list` role should have `listitem` children, which this one doesn't have.