### PR TITLE
Avoid showing a horizontal scrollbar on the home page

### DIFF
--- a/static/styles/home-page.css
+++ b/static/styles/home-page.css
@@ -5,7 +5,6 @@ body {
   grid-template-areas: "header header header" ". main socials";
   place-items: center;
   height: 100vh;
-  width: 100vw;
 }
 
 #site-header {


### PR DESCRIPTION
With the body set to `width: 100vw`, browsers with non-overlay scrollbars showed a horizontal scrollbar on the home page when there was also vertical scrolling, since `100vw` is the width of the window, including the vertical scrollbar. Since the body by default has the width of the window, accounting for scrollbars, removing it will fix this issue.