### PR TITLE
Fix the Deno Deploy PR preview redirecting to the production site

### DIFF
--- a/.github/server/main.ts
+++ b/.github/server/main.ts
@@ -22,7 +22,7 @@ serve((req) => {
   if (
     url.hostname !== "localhost" &&
     url.origin !== "https://andreubotella.com" &&
-    !/^https:\/\/andreubotella-com-[0-9a-z]+\.deno\.dev$/.test(url.origin)
+    !/^https:\/\/andreubotella-com-[0-9a-z-]+\.deno\.dev$/.test(url.origin)
   ) {
     return Response.redirect(
       replaceHost("https://andreubotella.com"),


### PR DESCRIPTION
It seems like Deno Deploy has changed how it does preview deployment subdomains.