### PR TITLE
Add `fediverse:creator` meta tag

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -13,6 +13,7 @@
     {% endif %}
     <title>{{ title }}</title>
     <meta name="author" content="Andreu Botella" />
+    <meta name="fediverse:creator" content="@andreu@andreubotella.com" />
     <link rel="preload" href="/fonts/FiraSans-Regular.woff2" as="font" crossorigin />
     <link rel="preload" href="/fonts/FiraSans-Italic.woff2" as="font" fetchpriority="low" crossorigin />
     <link rel="preload" href="/fonts/FiraSans-Bold.woff2" as="font" crossorigin />


### PR DESCRIPTION
See https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/.